### PR TITLE
Include cmath to fix compilation errors under Centos

### DIFF
--- a/TextExtraction/TextExtraction.cpp
+++ b/TextExtraction/TextExtraction.cpp
@@ -12,6 +12,7 @@
 #include "./lib/bidi/BidiConversion.h"
 
 #include <algorithm>
+#include <cmath>
 
 using namespace std;
 using namespace PDFHummus;


### PR DESCRIPTION
Just added include statement required to make it compile under Centos 7